### PR TITLE
Introducing channel messaging to reformcloud2

### DIFF
--- a/reformcloud2-executor-api/src/main/java/systems/reformcloud/reformcloud2/executor/api/common/api/AsyncAPI.java
+++ b/reformcloud2-executor-api/src/main/java/systems/reformcloud/reformcloud2/executor/api/common/api/AsyncAPI.java
@@ -6,6 +6,7 @@ import systems.reformcloud.reformcloud2.executor.api.common.api.client.ClientAsy
 import systems.reformcloud.reformcloud2.executor.api.common.api.console.ConsoleAsyncAPI;
 import systems.reformcloud.reformcloud2.executor.api.common.api.database.DatabaseAsyncAPI;
 import systems.reformcloud.reformcloud2.executor.api.common.api.group.GroupAsyncAPI;
+import systems.reformcloud.reformcloud2.executor.api.common.api.messaging.MessageAsyncAPI;
 import systems.reformcloud.reformcloud2.executor.api.common.api.player.PlayerAsyncAPI;
 import systems.reformcloud.reformcloud2.executor.api.common.api.plugins.PluginAsyncAPI;
 import systems.reformcloud.reformcloud2.executor.api.common.api.process.ProcessAsyncAPI;
@@ -66,4 +67,10 @@ public interface AsyncAPI {
      */
     @Nonnull
     DatabaseAsyncAPI getDatabaseAsyncAPI();
+
+    /**
+     * @return The current messaging async api instance
+     */
+    @Nonnull
+    MessageAsyncAPI getMessageAsyncAPI();
 }

--- a/reformcloud2-executor-api/src/main/java/systems/reformcloud/reformcloud2/executor/api/common/api/SyncAPI.java
+++ b/reformcloud2-executor-api/src/main/java/systems/reformcloud/reformcloud2/executor/api/common/api/SyncAPI.java
@@ -6,6 +6,7 @@ import systems.reformcloud.reformcloud2.executor.api.common.api.client.ClientSyn
 import systems.reformcloud.reformcloud2.executor.api.common.api.console.ConsoleSyncAPI;
 import systems.reformcloud.reformcloud2.executor.api.common.api.database.DatabaseSyncAPI;
 import systems.reformcloud.reformcloud2.executor.api.common.api.group.GroupSyncAPI;
+import systems.reformcloud.reformcloud2.executor.api.common.api.messaging.MessageSyncAPI;
 import systems.reformcloud.reformcloud2.executor.api.common.api.player.PlayerSyncAPI;
 import systems.reformcloud.reformcloud2.executor.api.common.api.plugins.PluginSyncAPI;
 import systems.reformcloud.reformcloud2.executor.api.common.api.process.ProcessSyncAPI;
@@ -66,4 +67,10 @@ public interface SyncAPI {
      */
     @Nonnull
     DatabaseSyncAPI getDatabaseSyncAPI();
+
+    /**
+     * @return The current messaging sync api instance
+     */
+    @Nonnull
+    MessageSyncAPI getMessageSyncAPI();
 }

--- a/reformcloud2-executor-api/src/main/java/systems/reformcloud/reformcloud2/executor/api/common/api/applications/api/GeneralAPI.java
+++ b/reformcloud2-executor-api/src/main/java/systems/reformcloud/reformcloud2/executor/api/common/api/applications/api/GeneralAPI.java
@@ -13,6 +13,8 @@ import systems.reformcloud.reformcloud2.executor.api.common.api.database.Databas
 import systems.reformcloud.reformcloud2.executor.api.common.api.database.DatabaseSyncAPI;
 import systems.reformcloud.reformcloud2.executor.api.common.api.group.GroupAsyncAPI;
 import systems.reformcloud.reformcloud2.executor.api.common.api.group.GroupSyncAPI;
+import systems.reformcloud.reformcloud2.executor.api.common.api.messaging.MessageAsyncAPI;
+import systems.reformcloud.reformcloud2.executor.api.common.api.messaging.MessageSyncAPI;
 import systems.reformcloud.reformcloud2.executor.api.common.api.player.PlayerAsyncAPI;
 import systems.reformcloud.reformcloud2.executor.api.common.api.player.PlayerSyncAPI;
 import systems.reformcloud.reformcloud2.executor.api.common.api.plugins.PluginAsyncAPI;
@@ -80,6 +82,12 @@ public class GeneralAPI implements SyncAPI, AsyncAPI {
 
     @Nonnull
     @Override
+    public MessageAsyncAPI getMessageAsyncAPI() {
+        return externalAPIImplementation;
+    }
+
+    @Nonnull
+    @Override
     public ProcessSyncAPI getProcessSyncAPI() {
         return externalAPIImplementation;
     }
@@ -123,6 +131,12 @@ public class GeneralAPI implements SyncAPI, AsyncAPI {
     @Nonnull
     @Override
     public DatabaseSyncAPI getDatabaseSyncAPI() {
+        return externalAPIImplementation;
+    }
+
+    @Nonnull
+    @Override
+    public MessageSyncAPI getMessageSyncAPI() {
         return externalAPIImplementation;
     }
 }

--- a/reformcloud2-executor-api/src/main/java/systems/reformcloud/reformcloud2/executor/api/common/api/basic/events/ChannelMessageReceivedEvent.java
+++ b/reformcloud2-executor-api/src/main/java/systems/reformcloud/reformcloud2/executor/api/common/api/basic/events/ChannelMessageReceivedEvent.java
@@ -1,0 +1,17 @@
+package systems.reformcloud.reformcloud2.executor.api.common.api.basic.events;
+
+import systems.reformcloud.reformcloud2.executor.api.common.configuration.JsonConfiguration;
+import systems.reformcloud.reformcloud2.executor.api.common.event.Event;
+
+public class ChannelMessageReceivedEvent extends Event {
+
+    public ChannelMessageReceivedEvent(JsonConfiguration content) {
+        this.content = content;
+    }
+
+    private final JsonConfiguration content;
+
+    public JsonConfiguration getContent() {
+        return content;
+    }
+}

--- a/reformcloud2-executor-api/src/main/java/systems/reformcloud/reformcloud2/executor/api/common/api/messaging/MessageAsyncAPI.java
+++ b/reformcloud2-executor-api/src/main/java/systems/reformcloud/reformcloud2/executor/api/common/api/messaging/MessageAsyncAPI.java
@@ -13,7 +13,7 @@ public interface MessageAsyncAPI {
      *
      * @param receiver          The receiver of the channel message
      * @param jsonConfiguration The content which should get sent
-     * @return A task which will get completed when the message got sent to all senders
+     * @return A task which will get completed when the message got sent to all receivers
      */
     @Nonnull
     default Task<Void> sendChannelMessageAsync(@Nonnull String receiver, @Nonnull JsonConfiguration jsonConfiguration) {
@@ -25,7 +25,7 @@ public interface MessageAsyncAPI {
      *
      * @param jsonConfiguration The content which should get sent
      * @param receivers         The receivers of the channel message
-     * @return A task which will get completed when the message got sent to all senders
+     * @return A task which will get completed when the message got sent to all receivers
      */
     @Nonnull
     default Task<Void> sendChannelMessageAsync(@Nonnull JsonConfiguration jsonConfiguration, @Nonnull String... receivers) {
@@ -39,7 +39,7 @@ public interface MessageAsyncAPI {
      * @param jsonConfiguration   The content which should get sent
      * @param errorReportHandling The handling type of errors if a channel is not available in the network
      * @param receivers           The receivers of the channel message
-     * @return A task which will get completed when the message got sent to all senders
+     * @return A task which will get completed when the message got sent to all receivers
      */
     @Nonnull
     Task<Void> sendChannelMessageAsync(@Nonnull JsonConfiguration jsonConfiguration, @Nonnull ErrorReportHandling errorReportHandling, @Nonnull String... receivers);

--- a/reformcloud2-executor-api/src/main/java/systems/reformcloud/reformcloud2/executor/api/common/api/messaging/MessageAsyncAPI.java
+++ b/reformcloud2-executor-api/src/main/java/systems/reformcloud/reformcloud2/executor/api/common/api/messaging/MessageAsyncAPI.java
@@ -8,16 +8,39 @@ import javax.annotation.Nonnull;
 
 public interface MessageAsyncAPI {
 
+    /**
+     * Sends a channel message to the specified sender
+     *
+     * @param receiver          The receiver of the channel message
+     * @param jsonConfiguration The content which should get sent
+     * @return A task which will get completed when the message got sent to all senders
+     */
     @Nonnull
     default Task<Void> sendChannelMessageAsync(@Nonnull String receiver, @Nonnull JsonConfiguration jsonConfiguration) {
         return sendChannelMessageAsync(jsonConfiguration, receiver);
     }
 
+    /**
+     * Sends a channel message to a bunch of receivers
+     *
+     * @param jsonConfiguration The content which should get sent
+     * @param receivers         The receivers of the channel message
+     * @return A task which will get completed when the message got sent to all senders
+     */
     @Nonnull
     default Task<Void> sendChannelMessageAsync(@Nonnull JsonConfiguration jsonConfiguration, @Nonnull String... receivers) {
         return sendChannelMessageAsync(jsonConfiguration, ErrorReportHandling.NOTHING, receivers);
     }
 
+    /**
+     * Sends a channel message to a bunch of receivers and specifies the error handling if a specified
+     * receiver is not available in the network
+     *
+     * @param jsonConfiguration   The content which should get sent
+     * @param errorReportHandling The handling type of errors if a channel is not available in the network
+     * @param receivers           The receivers of the channel message
+     * @return A task which will get completed when the message got sent to all senders
+     */
     @Nonnull
     Task<Void> sendChannelMessageAsync(@Nonnull JsonConfiguration jsonConfiguration, @Nonnull ErrorReportHandling errorReportHandling, @Nonnull String... receivers);
 }

--- a/reformcloud2-executor-api/src/main/java/systems/reformcloud/reformcloud2/executor/api/common/api/messaging/MessageAsyncAPI.java
+++ b/reformcloud2-executor-api/src/main/java/systems/reformcloud/reformcloud2/executor/api/common/api/messaging/MessageAsyncAPI.java
@@ -1,0 +1,23 @@
+package systems.reformcloud.reformcloud2.executor.api.common.api.messaging;
+
+import systems.reformcloud.reformcloud2.executor.api.common.api.messaging.util.ErrorReportHandling;
+import systems.reformcloud.reformcloud2.executor.api.common.configuration.JsonConfiguration;
+import systems.reformcloud.reformcloud2.executor.api.common.utility.task.Task;
+
+import javax.annotation.Nonnull;
+
+public interface MessageAsyncAPI {
+
+    @Nonnull
+    default Task<Void> sendChannelMessageAsync(@Nonnull String receiver, @Nonnull JsonConfiguration jsonConfiguration) {
+        return sendChannelMessageAsync(jsonConfiguration, receiver);
+    }
+
+    @Nonnull
+    default Task<Void> sendChannelMessageAsync(@Nonnull JsonConfiguration jsonConfiguration, @Nonnull String... receivers) {
+        return sendChannelMessageAsync(jsonConfiguration, ErrorReportHandling.NOTHING, receivers);
+    }
+
+    @Nonnull
+    Task<Void> sendChannelMessageAsync(@Nonnull JsonConfiguration jsonConfiguration, @Nonnull ErrorReportHandling errorReportHandling, @Nonnull String... receivers);
+}

--- a/reformcloud2-executor-api/src/main/java/systems/reformcloud/reformcloud2/executor/api/common/api/messaging/MessageSyncAPI.java
+++ b/reformcloud2-executor-api/src/main/java/systems/reformcloud/reformcloud2/executor/api/common/api/messaging/MessageSyncAPI.java
@@ -7,13 +7,33 @@ import javax.annotation.Nonnull;
 
 public interface MessageSyncAPI {
 
+    /**
+     * Sends a channel message to the specified sender
+     *
+     * @param receiver          The receiver of the channel message
+     * @param jsonConfiguration The content which should get sent
+     */
     default void sendChannelMessageSync(@Nonnull String receiver, @Nonnull JsonConfiguration jsonConfiguration) {
         sendChannelMessageSync(jsonConfiguration, receiver);
     }
 
+    /**
+     * Sends a channel message to a bunch of receivers
+     *
+     * @param jsonConfiguration The content which should get sent
+     * @param receivers         The receivers of the channel message
+     */
     default void sendChannelMessageSync(@Nonnull JsonConfiguration jsonConfiguration, @Nonnull String... receivers) {
         sendChannelMessageSync(jsonConfiguration, ErrorReportHandling.NOTHING, receivers);
     }
 
+    /**
+     * Sends a channel message to a bunch of receivers and specifies the error handling if a specified
+     * receiver is not available in the network
+     *
+     * @param jsonConfiguration   The content which should get sent
+     * @param errorReportHandling The handling type of errors if a channel is not available in the network
+     * @param receivers           The receivers of the channel message
+     */
     void sendChannelMessageSync(@Nonnull JsonConfiguration jsonConfiguration, @Nonnull ErrorReportHandling errorReportHandling, @Nonnull String... receivers);
 }

--- a/reformcloud2-executor-api/src/main/java/systems/reformcloud/reformcloud2/executor/api/common/api/messaging/MessageSyncAPI.java
+++ b/reformcloud2-executor-api/src/main/java/systems/reformcloud/reformcloud2/executor/api/common/api/messaging/MessageSyncAPI.java
@@ -1,0 +1,19 @@
+package systems.reformcloud.reformcloud2.executor.api.common.api.messaging;
+
+import systems.reformcloud.reformcloud2.executor.api.common.api.messaging.util.ErrorReportHandling;
+import systems.reformcloud.reformcloud2.executor.api.common.configuration.JsonConfiguration;
+
+import javax.annotation.Nonnull;
+
+public interface MessageSyncAPI {
+
+    default void sendChannelMessageSync(@Nonnull String receiver, @Nonnull JsonConfiguration jsonConfiguration) {
+        sendChannelMessageSync(jsonConfiguration, receiver);
+    }
+
+    default void sendChannelMessageSync(@Nonnull JsonConfiguration jsonConfiguration, @Nonnull String... receivers) {
+        sendChannelMessageSync(jsonConfiguration, ErrorReportHandling.NOTHING, receivers);
+    }
+
+    void sendChannelMessageSync(@Nonnull JsonConfiguration jsonConfiguration, @Nonnull ErrorReportHandling errorReportHandling, @Nonnull String... receivers);
+}

--- a/reformcloud2-executor-api/src/main/java/systems/reformcloud/reformcloud2/executor/api/common/api/messaging/util/ErrorReportHandling.java
+++ b/reformcloud2-executor-api/src/main/java/systems/reformcloud/reformcloud2/executor/api/common/api/messaging/util/ErrorReportHandling.java
@@ -1,0 +1,10 @@
+package systems.reformcloud.reformcloud2.executor.api.common.api.messaging.util;
+
+public enum ErrorReportHandling {
+
+    THROW_EXCEPTION,
+
+    PRINT_ERROR,
+
+    NOTHING
+}

--- a/reformcloud2-executor-api/src/main/java/systems/reformcloud/reformcloud2/executor/api/common/network/NetworkUtil.java
+++ b/reformcloud2-executor-api/src/main/java/systems/reformcloud/reformcloud2/executor/api/common/network/NetworkUtil.java
@@ -55,6 +55,8 @@ public final class NetworkUtil {
 
     public static final int EXTERNAL_BUS = 50000;
 
+    public static final int MESSAGING_BUS = 60000;
+
     /* ============================ */
 
     public static final Executor EXECUTOR = Executors.newCachedThreadPool();

--- a/reformcloud2-executor-api/src/main/java/systems/reformcloud/reformcloud2/executor/api/common/network/messaging/DefaultMessageJsonPacket.java
+++ b/reformcloud2-executor-api/src/main/java/systems/reformcloud/reformcloud2/executor/api/common/network/messaging/DefaultMessageJsonPacket.java
@@ -1,0 +1,20 @@
+package systems.reformcloud.reformcloud2.executor.api.common.network.messaging;
+
+import systems.reformcloud.reformcloud2.executor.api.common.api.messaging.util.ErrorReportHandling;
+import systems.reformcloud.reformcloud2.executor.api.common.configuration.JsonConfiguration;
+import systems.reformcloud.reformcloud2.executor.api.common.network.NetworkUtil;
+import systems.reformcloud.reformcloud2.executor.api.common.network.packet.JsonPacket;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+
+public class DefaultMessageJsonPacket extends JsonPacket {
+
+    public DefaultMessageJsonPacket(@Nonnull JsonConfiguration content, @Nonnull Collection<String> receivers, @Nonnull ErrorReportHandling handling) {
+        super(NetworkUtil.MESSAGING_BUS + 1, new JsonConfiguration()
+                .add("receivers", receivers)
+                .add("handling", handling)
+                .add("message", content)
+        );
+    }
+}

--- a/reformcloud2-executor-api/src/main/java/systems/reformcloud/reformcloud2/executor/api/common/network/messaging/ProxiedChannelMessageHandler.java
+++ b/reformcloud2-executor-api/src/main/java/systems/reformcloud/reformcloud2/executor/api/common/network/messaging/ProxiedChannelMessageHandler.java
@@ -1,0 +1,24 @@
+package systems.reformcloud.reformcloud2.executor.api.common.network.messaging;
+
+import systems.reformcloud.reformcloud2.executor.api.common.ExecutorAPI;
+import systems.reformcloud.reformcloud2.executor.api.common.api.basic.events.ChannelMessageReceivedEvent;
+import systems.reformcloud.reformcloud2.executor.api.common.network.NetworkUtil;
+import systems.reformcloud.reformcloud2.executor.api.common.network.channel.PacketSender;
+import systems.reformcloud.reformcloud2.executor.api.common.network.channel.handler.DefaultJsonNetworkHandler;
+import systems.reformcloud.reformcloud2.executor.api.common.network.packet.Packet;
+
+import javax.annotation.Nonnull;
+import java.util.function.Consumer;
+
+public class ProxiedChannelMessageHandler extends DefaultJsonNetworkHandler {
+
+    @Override
+    public int getHandlingPacketID() {
+        return NetworkUtil.MESSAGING_BUS + 2;
+    }
+
+    @Override
+    public void handlePacket(@Nonnull PacketSender packetSender, @Nonnull Packet packet, @Nonnull Consumer<Packet> responses) {
+        ExecutorAPI.getInstance().getEventManager().callEvent(new ChannelMessageReceivedEvent(packet.content()));
+    }
+}

--- a/reformcloud2-executor-api/src/main/java/systems/reformcloud/reformcloud2/executor/api/common/utility/optional/ReferencedOptional.java
+++ b/reformcloud2-executor-api/src/main/java/systems/reformcloud/reformcloud2/executor/api/common/utility/optional/ReferencedOptional.java
@@ -5,6 +5,7 @@ import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 public final class ReferencedOptional<T> implements Serializable {
 
@@ -17,7 +18,6 @@ public final class ReferencedOptional<T> implements Serializable {
         return new ReferencedOptional<>();
     }
 
-    @SuppressWarnings("unchecked")
     @Nonnull
     public static <T> ReferencedOptional<T> build(@Nullable T value) {
         return new ReferencedOptional<T>().update(value);
@@ -28,7 +28,7 @@ public final class ReferencedOptional<T> implements Serializable {
     private final AtomicReference<T> reference = new AtomicReference<>();
 
     @Nonnull
-    public ReferencedOptional update(@Nullable T newValue) {
+    public ReferencedOptional<T> update(@Nullable T newValue) {
         if (newValue != null) {
             reference.set(newValue);
         }
@@ -56,6 +56,16 @@ public final class ReferencedOptional<T> implements Serializable {
         }
 
         return value;
+    }
+
+    public void orElseDo(@Nonnull Predicate<T> predicate, @Nonnull Runnable ifFalse, @Nonnull Consumer<T> or) {
+        T value = reference.get();
+        if (!predicate.test(value)) {
+            ifFalse.run();
+            return;
+        }
+
+        or.accept(value);
     }
 
     public boolean isPresent() {

--- a/reformcloud2-executor-api/src/main/resources/languages/de_formal.properties
+++ b/reformcloud2-executor-api/src/main/resources/languages/de_formal.properties
@@ -19,6 +19,8 @@ network-client-connection-refused=Es konnte keine Verbindung zu {0}:{1} aufgebau
 network-client-connection-lost=Die Verbindung zum Regler wurde geschlossen
 network-received-invalid-packet=Ein falsches Paket wurde erkannt (Name: {0} Gesendet von {1})
 
+message-api-network-sender-not-available=Der gewünschte Partizipant {0} ist dem Netzwerk nicht beigetreten
+
 network-node-no-other-nodes-defined=Es wurden keine anderen Knoten in der Konfiguration angegeben
 network-node-try-connect-with-no-key=Es wurde kein Verbindungs-Schlüssel angegeben, daher kann keine \
   Verbindung zu anderen Knoten aufgebaut werden

--- a/reformcloud2-executor-api/src/main/resources/languages/en.properties
+++ b/reformcloud2-executor-api/src/main/resources/languages/en.properties
@@ -22,6 +22,8 @@ network-node-try-connect-with-no-key=No key defined (the node cannot connect to 
 network-node-connection-to-other-node-success=Successfully connected to {0}:{1}
 network-node-connection-to-other-node-not-successful=Could not connect to {0}:{1} (already connected?)
 
+message-api-network-sender-not-available=The network sender {0} is not available
+
 player-logged-in=Player {0} logged in on proxy {1}
 player-logged-out=Player {0}/{1} logged out on proxy {2}
 player-executed-command=Player {0}/{1} executed the command "{2}" on {3}

--- a/reformcloud2-executor/src/main/java/systems/reformcloud/reformcloud2/executor/api/bungee/BungeeExecutor.java
+++ b/reformcloud2-executor/src/main/java/systems/reformcloud/reformcloud2/executor/api/bungee/BungeeExecutor.java
@@ -28,6 +28,7 @@ import systems.reformcloud.reformcloud2.executor.api.common.network.channel.Pack
 import systems.reformcloud.reformcloud2.executor.api.common.network.channel.manager.DefaultChannelManager;
 import systems.reformcloud.reformcloud2.executor.api.common.network.client.DefaultNetworkClient;
 import systems.reformcloud.reformcloud2.executor.api.common.network.client.NetworkClient;
+import systems.reformcloud.reformcloud2.executor.api.common.network.messaging.ProxiedChannelMessageHandler;
 import systems.reformcloud.reformcloud2.executor.api.common.network.packet.defaults.DefaultPacketHandler;
 import systems.reformcloud.reformcloud2.executor.api.common.network.packet.handler.PacketHandler;
 import systems.reformcloud.reformcloud2.executor.api.common.process.ProcessInformation;
@@ -81,24 +82,17 @@ public final class BungeeExecutor extends API implements PlayerAPIExecutor {
         getEventManager().registerListener(this);
 
         packetHandler.registerHandler(new APIPacketInAPIAction(this));
-        packetHandler.registerHandler(
-                new APIPacketInPluginAction(new PluginExecutorContainer()));
+        packetHandler.registerHandler(new APIPacketInPluginAction(new PluginExecutorContainer()));
+        packetHandler.registerHandler(new ProxiedChannelMessageHandler());
 
-        String connectionKey =
-                JsonConfiguration.read("reformcloud/.connection/key.json")
-                        .getString("key");
+        String connectionKey = JsonConfiguration.read("reformcloud/.connection/key.json").getString("key");
         SystemHelper.deleteFile(new File("reformcloud/.connection/key.json"));
-        JsonConfiguration connectionConfig =
-                JsonConfiguration.read("reformcloud/.connection/connection.json");
+        JsonConfiguration connectionConfig = JsonConfiguration.read("reformcloud/.connection/connection.json");
 
-        this.thisProcessInformation =
-                connectionConfig.get("startInfo", ProcessInformation.TYPE);
-        waterdog = thisProcessInformation.getTemplate().getVersion().equals(
-                Version.WATERDOG) ||
-                thisProcessInformation.getTemplate().getVersion().equals(
-                        Version.WATERDOG_PE);
-        waterdogPE = thisProcessInformation.getTemplate().getVersion().equals(
-                Version.WATERDOG_PE);
+        this.thisProcessInformation = connectionConfig.get("startInfo", ProcessInformation.TYPE);
+        waterdog = thisProcessInformation.getTemplate().getVersion().equals(Version.WATERDOG)
+                || thisProcessInformation.getTemplate().getVersion().equals(Version.WATERDOG_PE);
+        waterdogPE = thisProcessInformation.getTemplate().getVersion().equals(Version.WATERDOG_PE);
 
         this.networkClient.connect(
                 connectionConfig.getString("controller-host"),

--- a/reformcloud2-executor/src/main/java/systems/reformcloud/reformcloud2/executor/api/nukkit/NukkitExecutor.java
+++ b/reformcloud2-executor/src/main/java/systems/reformcloud/reformcloud2/executor/api/nukkit/NukkitExecutor.java
@@ -20,6 +20,7 @@ import systems.reformcloud.reformcloud2.executor.api.common.network.channel.Pack
 import systems.reformcloud.reformcloud2.executor.api.common.network.channel.manager.DefaultChannelManager;
 import systems.reformcloud.reformcloud2.executor.api.common.network.client.DefaultNetworkClient;
 import systems.reformcloud.reformcloud2.executor.api.common.network.client.NetworkClient;
+import systems.reformcloud.reformcloud2.executor.api.common.network.messaging.ProxiedChannelMessageHandler;
 import systems.reformcloud.reformcloud2.executor.api.common.network.packet.defaults.DefaultPacketHandler;
 import systems.reformcloud.reformcloud2.executor.api.common.network.packet.handler.PacketHandler;
 import systems.reformcloud.reformcloud2.executor.api.common.process.ProcessInformation;
@@ -61,6 +62,7 @@ public final class NukkitExecutor extends API implements PlayerAPIExecutor {
 
         packetHandler.registerHandler(new APIPacketInAPIAction(this));
         packetHandler.registerHandler(new APIPacketInPluginAction(new PluginsExecutorContainer()));
+        packetHandler.registerHandler(new ProxiedChannelMessageHandler());
 
         String connectionKey = JsonConfiguration.read("reformcloud/.connection/key.json").getString("key");
         SystemHelper.deleteFile(new File("reformcloud/.connection/key.json"));

--- a/reformcloud2-executor/src/main/java/systems/reformcloud/reformcloud2/executor/api/spigot/SpigotExecutor.java
+++ b/reformcloud2-executor/src/main/java/systems/reformcloud/reformcloud2/executor/api/spigot/SpigotExecutor.java
@@ -20,6 +20,7 @@ import systems.reformcloud.reformcloud2.executor.api.common.network.channel.Pack
 import systems.reformcloud.reformcloud2.executor.api.common.network.channel.manager.DefaultChannelManager;
 import systems.reformcloud.reformcloud2.executor.api.common.network.client.DefaultNetworkClient;
 import systems.reformcloud.reformcloud2.executor.api.common.network.client.NetworkClient;
+import systems.reformcloud.reformcloud2.executor.api.common.network.messaging.ProxiedChannelMessageHandler;
 import systems.reformcloud.reformcloud2.executor.api.common.network.packet.defaults.DefaultPacketHandler;
 import systems.reformcloud.reformcloud2.executor.api.common.network.packet.handler.PacketHandler;
 import systems.reformcloud.reformcloud2.executor.api.common.process.ProcessInformation;
@@ -60,6 +61,7 @@ public final class SpigotExecutor extends API implements PlayerAPIExecutor {
 
         packetHandler.registerHandler(new APIPacketInAPIAction(this));
         packetHandler.registerHandler(new APIPacketInPluginAction(new PluginExecutorContainer()));
+        packetHandler.registerHandler(new ProxiedChannelMessageHandler());
 
         String connectionKey = JsonConfiguration.read("reformcloud/.connection/key.json").getString("key");
         SystemHelper.deleteFile(new File("reformcloud/.connection/key.json"));

--- a/reformcloud2-executor/src/main/java/systems/reformcloud/reformcloud2/executor/api/sponge/SpongeExecutor.java
+++ b/reformcloud2-executor/src/main/java/systems/reformcloud/reformcloud2/executor/api/sponge/SpongeExecutor.java
@@ -23,6 +23,7 @@ import systems.reformcloud.reformcloud2.executor.api.common.network.channel.Pack
 import systems.reformcloud.reformcloud2.executor.api.common.network.channel.manager.DefaultChannelManager;
 import systems.reformcloud.reformcloud2.executor.api.common.network.client.DefaultNetworkClient;
 import systems.reformcloud.reformcloud2.executor.api.common.network.client.NetworkClient;
+import systems.reformcloud.reformcloud2.executor.api.common.network.messaging.ProxiedChannelMessageHandler;
 import systems.reformcloud.reformcloud2.executor.api.common.network.packet.defaults.DefaultPacketHandler;
 import systems.reformcloud.reformcloud2.executor.api.common.network.packet.handler.PacketHandler;
 import systems.reformcloud.reformcloud2.executor.api.common.process.ProcessInformation;
@@ -60,6 +61,7 @@ public class SpongeExecutor extends API implements PlayerAPIExecutor {
         instance = this;
 
         packetHandler.registerHandler(new APIPacketInAPIAction(this));
+        packetHandler.registerHandler(new ProxiedChannelMessageHandler());
 
         new ExternalEventBusHandler(packetHandler, new DefaultEventManager());
         getEventManager().registerListener(this);

--- a/reformcloud2-executor/src/main/java/systems/reformcloud/reformcloud2/executor/api/velocity/VelocityExecutor.java
+++ b/reformcloud2-executor/src/main/java/systems/reformcloud/reformcloud2/executor/api/velocity/VelocityExecutor.java
@@ -22,6 +22,7 @@ import systems.reformcloud.reformcloud2.executor.api.common.network.channel.Pack
 import systems.reformcloud.reformcloud2.executor.api.common.network.channel.manager.DefaultChannelManager;
 import systems.reformcloud.reformcloud2.executor.api.common.network.client.DefaultNetworkClient;
 import systems.reformcloud.reformcloud2.executor.api.common.network.client.NetworkClient;
+import systems.reformcloud.reformcloud2.executor.api.common.network.messaging.ProxiedChannelMessageHandler;
 import systems.reformcloud.reformcloud2.executor.api.common.network.packet.defaults.DefaultPacketHandler;
 import systems.reformcloud.reformcloud2.executor.api.common.network.packet.handler.PacketHandler;
 import systems.reformcloud.reformcloud2.executor.api.common.process.ProcessInformation;
@@ -73,6 +74,7 @@ public final class VelocityExecutor extends API implements PlayerAPIExecutor {
         getEventManager().registerListener(this);
         proxyServer.getEventManager().register(launcher, new PlayerListenerHandler());
 
+        packetHandler.registerHandler(new ProxiedChannelMessageHandler());
         packetHandler.registerHandler(new APIPacketInAPIAction(this));
         packetHandler.registerHandler(new APIPacketInPluginAction(new PluginExecutorContainer()));
 

--- a/reformcloud2-executor/src/main/java/systems/reformcloud/reformcloud2/executor/client/ClientExecutor.java
+++ b/reformcloud2-executor/src/main/java/systems/reformcloud/reformcloud2/executor/client/ClientExecutor.java
@@ -34,6 +34,7 @@ import systems.reformcloud.reformcloud2.executor.api.common.network.channel.hand
 import systems.reformcloud.reformcloud2.executor.api.common.network.channel.manager.DefaultChannelManager;
 import systems.reformcloud.reformcloud2.executor.api.common.network.client.DefaultNetworkClient;
 import systems.reformcloud.reformcloud2.executor.api.common.network.client.NetworkClient;
+import systems.reformcloud.reformcloud2.executor.api.common.network.messaging.ProxiedChannelMessageHandler;
 import systems.reformcloud.reformcloud2.executor.api.common.network.packet.defaults.DefaultPacketHandler;
 import systems.reformcloud.reformcloud2.executor.api.common.network.packet.handler.PacketHandler;
 import systems.reformcloud.reformcloud2.executor.api.common.process.ProcessInformation;
@@ -157,6 +158,7 @@ public final class ClientExecutor extends Client {
 
     private void registerNetworkHandlers() {
         new Reflections("systems.reformcloud.reformcloud2.executor.client.packet.in").getSubTypesOf(DefaultJsonNetworkHandler.class).forEach(packetHandler::registerHandler);
+        this.packetHandler.registerHandler(new ProxiedChannelMessageHandler());
     }
 
     private void registerDefaultCommands() {

--- a/reformcloud2-executor/src/main/java/systems/reformcloud/reformcloud2/executor/controller/ControllerExecutor.java
+++ b/reformcloud2-executor/src/main/java/systems/reformcloud/reformcloud2/executor/controller/ControllerExecutor.java
@@ -62,6 +62,7 @@ import systems.reformcloud.reformcloud2.executor.controller.api.client.ClientAPI
 import systems.reformcloud.reformcloud2.executor.controller.api.console.ConsoleAPIImplementation;
 import systems.reformcloud.reformcloud2.executor.controller.api.database.DatabaseAPIImplementation;
 import systems.reformcloud.reformcloud2.executor.controller.api.group.GroupAPIImplementation;
+import systems.reformcloud.reformcloud2.executor.controller.api.message.ChannelMessageAPIImplementation;
 import systems.reformcloud.reformcloud2.executor.controller.api.player.PlayerAPIImplementation;
 import systems.reformcloud.reformcloud2.executor.controller.api.plugins.PluginAPIImplementation;
 import systems.reformcloud.reformcloud2.executor.controller.api.process.ProcessAPIImplementation;
@@ -187,7 +188,8 @@ public final class ControllerExecutor extends Controller {
                 new GroupAPIImplementation(),
                 new PlayerAPIImplementation(this.processManager),
                 new PluginAPIImplementation(),
-                new ProcessAPIImplementation(this.processManager)
+                new ProcessAPIImplementation(this.processManager),
+                new ChannelMessageAPIImplementation()
         );
         this.syncAPI = generalAPI;
         this.asyncAPI = generalAPI;

--- a/reformcloud2-executor/src/main/java/systems/reformcloud/reformcloud2/executor/controller/api/GeneralAPI.java
+++ b/reformcloud2-executor/src/main/java/systems/reformcloud/reformcloud2/executor/controller/api/GeneralAPI.java
@@ -12,6 +12,8 @@ import systems.reformcloud.reformcloud2.executor.api.common.api.database.Databas
 import systems.reformcloud.reformcloud2.executor.api.common.api.database.DatabaseSyncAPI;
 import systems.reformcloud.reformcloud2.executor.api.common.api.group.GroupAsyncAPI;
 import systems.reformcloud.reformcloud2.executor.api.common.api.group.GroupSyncAPI;
+import systems.reformcloud.reformcloud2.executor.api.common.api.messaging.MessageAsyncAPI;
+import systems.reformcloud.reformcloud2.executor.api.common.api.messaging.MessageSyncAPI;
 import systems.reformcloud.reformcloud2.executor.api.common.api.player.PlayerAsyncAPI;
 import systems.reformcloud.reformcloud2.executor.api.common.api.player.PlayerSyncAPI;
 import systems.reformcloud.reformcloud2.executor.api.common.api.plugins.PluginAsyncAPI;
@@ -23,6 +25,7 @@ import systems.reformcloud.reformcloud2.executor.controller.api.client.ClientAPI
 import systems.reformcloud.reformcloud2.executor.controller.api.console.ConsoleAPIImplementation;
 import systems.reformcloud.reformcloud2.executor.controller.api.database.DatabaseAPIImplementation;
 import systems.reformcloud.reformcloud2.executor.controller.api.group.GroupAPIImplementation;
+import systems.reformcloud.reformcloud2.executor.controller.api.message.ChannelMessageAPIImplementation;
 import systems.reformcloud.reformcloud2.executor.controller.api.player.PlayerAPIImplementation;
 import systems.reformcloud.reformcloud2.executor.controller.api.plugins.PluginAPIImplementation;
 import systems.reformcloud.reformcloud2.executor.controller.api.process.ProcessAPIImplementation;
@@ -39,7 +42,8 @@ public class GeneralAPI implements SyncAPI, AsyncAPI {
             GroupAPIImplementation groupAPI,
             PlayerAPIImplementation playerAPI,
             PluginAPIImplementation pluginAPI,
-            ProcessAPIImplementation processAPI
+            ProcessAPIImplementation processAPI,
+            ChannelMessageAPIImplementation channelAPI
     ) {
         this.applicationAPI = applicationAPI;
         this.clientAPI = clientAPI;
@@ -49,6 +53,7 @@ public class GeneralAPI implements SyncAPI, AsyncAPI {
         this.playerAPI = playerAPI;
         this.pluginAPI = pluginAPI;
         this.processAPI = processAPI;
+        this.channelAPI = channelAPI;
     }
 
     private final ApplicationAPIImplementation applicationAPI;
@@ -66,6 +71,8 @@ public class GeneralAPI implements SyncAPI, AsyncAPI {
     private final PluginAPIImplementation pluginAPI;
 
     private final ProcessAPIImplementation processAPI;
+
+    private final ChannelMessageAPIImplementation channelAPI;
 
     @Nonnull
     @Override
@@ -117,6 +124,12 @@ public class GeneralAPI implements SyncAPI, AsyncAPI {
 
     @Nonnull
     @Override
+    public MessageAsyncAPI getMessageAsyncAPI() {
+        return this.channelAPI;
+    }
+
+    @Nonnull
+    @Override
     public ProcessSyncAPI getProcessSyncAPI() {
         return processAPI;
     }
@@ -161,5 +174,11 @@ public class GeneralAPI implements SyncAPI, AsyncAPI {
     @Override
     public DatabaseSyncAPI getDatabaseSyncAPI() {
         return databaseAPI;
+    }
+
+    @Nonnull
+    @Override
+    public MessageSyncAPI getMessageSyncAPI() {
+        return this.channelAPI;
     }
 }

--- a/reformcloud2-executor/src/main/java/systems/reformcloud/reformcloud2/executor/controller/api/message/ChannelMessageAPIImplementation.java
+++ b/reformcloud2-executor/src/main/java/systems/reformcloud/reformcloud2/executor/controller/api/message/ChannelMessageAPIImplementation.java
@@ -1,0 +1,49 @@
+package systems.reformcloud.reformcloud2.executor.controller.api.message;
+
+import systems.reformcloud.reformcloud2.executor.api.common.api.messaging.MessageAsyncAPI;
+import systems.reformcloud.reformcloud2.executor.api.common.api.messaging.MessageSyncAPI;
+import systems.reformcloud.reformcloud2.executor.api.common.api.messaging.util.ErrorReportHandling;
+import systems.reformcloud.reformcloud2.executor.api.common.configuration.JsonConfiguration;
+import systems.reformcloud.reformcloud2.executor.api.common.language.LanguageManager;
+import systems.reformcloud.reformcloud2.executor.api.common.network.channel.manager.DefaultChannelManager;
+import systems.reformcloud.reformcloud2.executor.api.common.utility.task.Task;
+import systems.reformcloud.reformcloud2.executor.api.common.utility.task.defaults.DefaultTask;
+import systems.reformcloud.reformcloud2.executor.controller.packet.out.messaging.ProxiedChannelMessage;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.Objects;
+
+public class ChannelMessageAPIImplementation implements MessageSyncAPI, MessageAsyncAPI {
+
+    @Nonnull
+    @Override
+    public Task<Void> sendChannelMessageAsync(@Nonnull JsonConfiguration jsonConfiguration, @Nonnull ErrorReportHandling errorReportHandling, @Nonnull String... receivers) {
+        Task<Void> task = new DefaultTask<>();
+        Task.EXECUTOR.execute(() -> {
+            Arrays.stream(receivers).forEach(receiver -> DefaultChannelManager.INSTANCE.get(receiver).orElseDo(Objects::nonNull, () -> {
+                switch (errorReportHandling) {
+                    case PRINT_ERROR: {
+                        System.err.println(LanguageManager.get("message-api-network-sender-not-available", receiver));
+                        break;
+                    }
+
+                    case THROW_EXCEPTION: {
+                        throw new RuntimeException(LanguageManager.get("message-api-network-sender-not-available", receiver));
+                    }
+
+                    case NOTHING:
+                    default:
+                        break;
+                }
+            }, sender -> sender.sendPacket(new ProxiedChannelMessage(jsonConfiguration))));
+            task.complete(null);
+        });
+        return task;
+    }
+
+    @Override
+    public void sendChannelMessageSync(@Nonnull JsonConfiguration jsonConfiguration, @Nonnull ErrorReportHandling errorReportHandling, @Nonnull String... receivers) {
+        sendChannelMessageAsync(jsonConfiguration, errorReportHandling, receivers).awaitUninterruptedly();
+    }
+}

--- a/reformcloud2-executor/src/main/java/systems/reformcloud/reformcloud2/executor/controller/packet/in/ControllerPacketInHandleChannelMessage.java
+++ b/reformcloud2-executor/src/main/java/systems/reformcloud/reformcloud2/executor/controller/packet/in/ControllerPacketInHandleChannelMessage.java
@@ -1,0 +1,37 @@
+package systems.reformcloud.reformcloud2.executor.controller.packet.in;
+
+import com.google.gson.reflect.TypeToken;
+import systems.reformcloud.reformcloud2.executor.api.common.ExecutorAPI;
+import systems.reformcloud.reformcloud2.executor.api.common.api.basic.events.ChannelMessageReceivedEvent;
+import systems.reformcloud.reformcloud2.executor.api.common.api.messaging.util.ErrorReportHandling;
+import systems.reformcloud.reformcloud2.executor.api.common.configuration.JsonConfiguration;
+import systems.reformcloud.reformcloud2.executor.api.common.network.NetworkUtil;
+import systems.reformcloud.reformcloud2.executor.api.common.network.channel.PacketSender;
+import systems.reformcloud.reformcloud2.executor.api.common.network.channel.handler.DefaultJsonNetworkHandler;
+import systems.reformcloud.reformcloud2.executor.api.common.network.packet.Packet;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.function.Consumer;
+
+public class ControllerPacketInHandleChannelMessage extends DefaultJsonNetworkHandler {
+
+    @Override
+    public int getHandlingPacketID() {
+        return NetworkUtil.MESSAGING_BUS + 1;
+    }
+
+    @Override
+    public void handlePacket(@Nonnull PacketSender packetSender, @Nonnull Packet packet, @Nonnull Consumer<Packet> responses) {
+        Collection<String> receivers = packet.content().get("receivers", new TypeToken<Collection<String>>() {});
+        ErrorReportHandling reportHandling = packet.content().get("handling", ErrorReportHandling.class);
+        JsonConfiguration message = packet.content().get("message");
+
+        if (receivers == null || reportHandling == null) {
+            return;
+        }
+
+        ExecutorAPI.getInstance().getSyncAPI().getMessageSyncAPI().sendChannelMessageSync(message, reportHandling, receivers.toArray(new String[0]));
+        ExecutorAPI.getInstance().getEventManager().callEvent(new ChannelMessageReceivedEvent(message));
+    }
+}

--- a/reformcloud2-executor/src/main/java/systems/reformcloud/reformcloud2/executor/controller/packet/out/messaging/ProxiedChannelMessage.java
+++ b/reformcloud2-executor/src/main/java/systems/reformcloud/reformcloud2/executor/controller/packet/out/messaging/ProxiedChannelMessage.java
@@ -1,0 +1,14 @@
+package systems.reformcloud.reformcloud2.executor.controller.packet.out.messaging;
+
+import systems.reformcloud.reformcloud2.executor.api.common.configuration.JsonConfiguration;
+import systems.reformcloud.reformcloud2.executor.api.common.network.NetworkUtil;
+import systems.reformcloud.reformcloud2.executor.api.common.network.packet.JsonPacket;
+
+import javax.annotation.Nonnull;
+
+public class ProxiedChannelMessage extends JsonPacket {
+
+    public ProxiedChannelMessage(@Nonnull JsonConfiguration content) {
+        super(NetworkUtil.MESSAGING_BUS + 2, content);
+    }
+}

--- a/reformcloud2-executor/src/main/java/systems/reformcloud/reformcloud2/executor/node/NodeExecutor.java
+++ b/reformcloud2-executor/src/main/java/systems/reformcloud/reformcloud2/executor/node/NodeExecutor.java
@@ -69,12 +69,14 @@ import systems.reformcloud.reformcloud2.executor.api.node.cluster.ClusterSyncMan
 import systems.reformcloud.reformcloud2.executor.api.node.cluster.SyncAction;
 import systems.reformcloud.reformcloud2.executor.api.node.network.NodeNetworkManager;
 import systems.reformcloud.reformcloud2.executor.controller.packet.in.ControllerPacketInAPIAction;
+import systems.reformcloud.reformcloud2.executor.controller.packet.in.ControllerPacketInHandleChannelMessage;
 import systems.reformcloud.reformcloud2.executor.node.api.GeneralAPI;
 import systems.reformcloud.reformcloud2.executor.node.api.applications.ApplicationAPIImplementation;
 import systems.reformcloud.reformcloud2.executor.node.api.client.ClientAPIImplementation;
 import systems.reformcloud.reformcloud2.executor.node.api.console.ConsoleAPIImplementation;
 import systems.reformcloud.reformcloud2.executor.node.api.database.DatabaseAPIImplementation;
 import systems.reformcloud.reformcloud2.executor.node.api.group.GroupAPIImplementation;
+import systems.reformcloud.reformcloud2.executor.node.api.message.ChannelMessageAPIImplementation;
 import systems.reformcloud.reformcloud2.executor.node.api.player.PlayerAPIImplementation;
 import systems.reformcloud.reformcloud2.executor.node.api.plugins.PluginAPIImplementation;
 import systems.reformcloud.reformcloud2.executor.node.api.process.ProcessAPIImplementation;
@@ -239,7 +241,8 @@ public class NodeExecutor extends Node {
                 new GroupAPIImplementation(this.clusterSyncManager),
                 new PlayerAPIImplementation(this.nodeNetworkManager),
                 new PluginAPIImplementation(this.nodeNetworkManager),
-                new ProcessAPIImplementation(this.nodeNetworkManager)
+                new ProcessAPIImplementation(this.nodeNetworkManager),
+                new ChannelMessageAPIImplementation()
         );
         this.syncAPI = generalAPI;
         this.asyncAPI = generalAPI;
@@ -673,7 +676,9 @@ public class NodeExecutor extends Node {
         });
 
         new Reflections("systems.reformcloud.reformcloud2.executor.node.network.packet.query.in").getSubTypesOf(DefaultJsonNetworkHandler.class).forEach(packetHandler::registerHandler);
+
         this.packetHandler.registerHandler(new ControllerPacketInAPIAction()); // External implementation which handles the api actions (we can re-use it)
+        this.packetHandler.registerHandler(new ControllerPacketInHandleChannelMessage()); // Implementation for the channel messaging api
     }
 
     private void sync(PacketSender sender) {

--- a/reformcloud2-executor/src/main/java/systems/reformcloud/reformcloud2/executor/node/api/GeneralAPI.java
+++ b/reformcloud2-executor/src/main/java/systems/reformcloud/reformcloud2/executor/node/api/GeneralAPI.java
@@ -12,6 +12,8 @@ import systems.reformcloud.reformcloud2.executor.api.common.api.database.Databas
 import systems.reformcloud.reformcloud2.executor.api.common.api.database.DatabaseSyncAPI;
 import systems.reformcloud.reformcloud2.executor.api.common.api.group.GroupAsyncAPI;
 import systems.reformcloud.reformcloud2.executor.api.common.api.group.GroupSyncAPI;
+import systems.reformcloud.reformcloud2.executor.api.common.api.messaging.MessageAsyncAPI;
+import systems.reformcloud.reformcloud2.executor.api.common.api.messaging.MessageSyncAPI;
 import systems.reformcloud.reformcloud2.executor.api.common.api.player.PlayerAsyncAPI;
 import systems.reformcloud.reformcloud2.executor.api.common.api.player.PlayerSyncAPI;
 import systems.reformcloud.reformcloud2.executor.api.common.api.plugins.PluginAsyncAPI;
@@ -23,6 +25,7 @@ import systems.reformcloud.reformcloud2.executor.node.api.client.ClientAPIImplem
 import systems.reformcloud.reformcloud2.executor.node.api.console.ConsoleAPIImplementation;
 import systems.reformcloud.reformcloud2.executor.node.api.database.DatabaseAPIImplementation;
 import systems.reformcloud.reformcloud2.executor.node.api.group.GroupAPIImplementation;
+import systems.reformcloud.reformcloud2.executor.node.api.message.ChannelMessageAPIImplementation;
 import systems.reformcloud.reformcloud2.executor.node.api.player.PlayerAPIImplementation;
 import systems.reformcloud.reformcloud2.executor.node.api.plugins.PluginAPIImplementation;
 import systems.reformcloud.reformcloud2.executor.node.api.process.ProcessAPIImplementation;
@@ -39,7 +42,8 @@ public class GeneralAPI implements SyncAPI, AsyncAPI {
             GroupAPIImplementation groupAPI,
             PlayerAPIImplementation playerAPI,
             PluginAPIImplementation pluginAPI,
-            ProcessAPIImplementation processAPI
+            ProcessAPIImplementation processAPI,
+            ChannelMessageAPIImplementation channelAPI
     ) {
         this.applicationAPI = applicationAPI;
         this.clientAPI = clientAPI;
@@ -49,6 +53,7 @@ public class GeneralAPI implements SyncAPI, AsyncAPI {
         this.playerAPI = playerAPI;
         this.pluginAPI = pluginAPI;
         this.processAPI = processAPI;
+        this.channelAPI = channelAPI;
     }
 
     private final ApplicationAPIImplementation applicationAPI;
@@ -66,6 +71,8 @@ public class GeneralAPI implements SyncAPI, AsyncAPI {
     private final PluginAPIImplementation pluginAPI;
 
     private final ProcessAPIImplementation processAPI;
+
+    private final ChannelMessageAPIImplementation channelAPI;
 
     @Nonnull
     @Override
@@ -117,6 +124,12 @@ public class GeneralAPI implements SyncAPI, AsyncAPI {
 
     @Nonnull
     @Override
+    public MessageAsyncAPI getMessageAsyncAPI() {
+        return this.channelAPI;
+    }
+
+    @Nonnull
+    @Override
     public ProcessSyncAPI getProcessSyncAPI() {
         return processAPI;
     }
@@ -161,5 +174,11 @@ public class GeneralAPI implements SyncAPI, AsyncAPI {
     @Override
     public DatabaseSyncAPI getDatabaseSyncAPI() {
         return databaseAPI;
+    }
+
+    @Nonnull
+    @Override
+    public MessageSyncAPI getMessageSyncAPI() {
+        return this.channelAPI;
     }
 }

--- a/reformcloud2-executor/src/main/java/systems/reformcloud/reformcloud2/executor/node/api/message/ChannelMessageAPIImplementation.java
+++ b/reformcloud2-executor/src/main/java/systems/reformcloud/reformcloud2/executor/node/api/message/ChannelMessageAPIImplementation.java
@@ -1,0 +1,58 @@
+package systems.reformcloud.reformcloud2.executor.node.api.message;
+
+import systems.reformcloud.reformcloud2.executor.api.common.api.messaging.MessageAsyncAPI;
+import systems.reformcloud.reformcloud2.executor.api.common.api.messaging.MessageSyncAPI;
+import systems.reformcloud.reformcloud2.executor.api.common.api.messaging.util.ErrorReportHandling;
+import systems.reformcloud.reformcloud2.executor.api.common.configuration.JsonConfiguration;
+import systems.reformcloud.reformcloud2.executor.api.common.language.LanguageManager;
+import systems.reformcloud.reformcloud2.executor.api.common.network.channel.manager.DefaultChannelManager;
+import systems.reformcloud.reformcloud2.executor.api.common.network.messaging.DefaultMessageJsonPacket;
+import systems.reformcloud.reformcloud2.executor.api.common.utility.task.Task;
+import systems.reformcloud.reformcloud2.executor.api.common.utility.task.defaults.DefaultTask;
+import systems.reformcloud.reformcloud2.executor.controller.packet.out.messaging.ProxiedChannelMessage;
+import systems.reformcloud.reformcloud2.executor.node.NodeExecutor;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.Objects;
+
+public class ChannelMessageAPIImplementation implements MessageSyncAPI, MessageAsyncAPI {
+
+    @Nonnull
+    @Override
+    public Task<Void> sendChannelMessageAsync(@Nonnull JsonConfiguration jsonConfiguration, @Nonnull ErrorReportHandling errorReportHandling, @Nonnull String... receivers) {
+        Task<Void> task = new DefaultTask<>();
+        Task.EXECUTOR.execute(() -> {
+            Arrays.stream(receivers).forEach(receiver -> DefaultChannelManager.INSTANCE.get(receiver).orElseDo(Objects::nonNull, () -> {
+                switch (errorReportHandling) {
+                    case PRINT_ERROR: {
+                        System.err.println(LanguageManager.get("message-api-network-sender-not-available", receiver));
+                        break;
+                    }
+
+                    case THROW_EXCEPTION: {
+                        throw new RuntimeException(LanguageManager.get("message-api-network-sender-not-available", receiver));
+                    }
+
+                    case NOTHING:
+                    default:
+                        break;
+                }
+            }, sender -> {
+                if (NodeExecutor.getInstance().getNodeNetworkManager().getCluster().getNode(sender.getName()) != null) {
+                    sender.sendPacket(new DefaultMessageJsonPacket(jsonConfiguration, Arrays.asList(receivers), errorReportHandling));
+                    return;
+                }
+
+                sender.sendPacket(new ProxiedChannelMessage(jsonConfiguration));
+            }));
+            task.complete(null);
+        });
+        return task;
+    }
+
+    @Override
+    public void sendChannelMessageSync(@Nonnull JsonConfiguration jsonConfiguration, @Nonnull ErrorReportHandling errorReportHandling, @Nonnull String... receivers) {
+        sendChannelMessageAsync(jsonConfiguration, errorReportHandling, receivers).awaitUninterruptedly();
+    }
+}


### PR DESCRIPTION
This introduces channel messaging to reformcloud2.

This is a useful feature for developers and server owner to communicate between servers without any application which handles the communiction from server to server.